### PR TITLE
Expose context object in config function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Create an Apollo configuration object (check out the [Apollo Client API](https:/
 import { withData } from 'next-apollo'
 import { HttpLink } from 'apollo-link-http'
 
-// can also be a function that accepts a `headers` object (SSR only) and returns a config
+// can also be a function that accepts a `context` object (SSR only) and returns a config
 const config = {
   link: new HttpLink({
     uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)

--- a/src/initApollo.js
+++ b/src/initApollo.js
@@ -27,9 +27,9 @@ function create(apolloConfig, initialState) {
   return new ApolloClient(config)
 }
 
-export default function initApollo(apolloConfig, initialState, headers) {
+export default function initApollo(apolloConfig, initialState, ctx) {
   if (isFunction(apolloConfig)) {
-    apolloConfig = apolloConfig(headers)
+    apolloConfig = apolloConfig(ctx)
   }
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)

--- a/src/withData.js
+++ b/src/withData.js
@@ -31,7 +31,7 @@ export default apolloConfig => {
         // Run all GraphQL queries in the component tree
         // and extract the resulting data
         if (!process.browser) {
-          const apollo = initApollo(apolloConfig, null, ctx.req.headers)
+          const apollo = initApollo(apolloConfig, null, ctx)
 
           // Provide the `url` prop data in case a GraphQL query uses it
           const url = { query: ctx.query, pathname: ctx.pathname }


### PR DESCRIPTION
#15 

Figure like `next-redux-wrapper` exposing the entire context object makes things flexible for just about any use case.