### PR TITLE
New HttpLink API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ import { HttpLink } from 'apollo-link-http'
 // can also be a function that accepts a `context` object (SSR only) and returns a config
 const config = {
   link: new HttpLink({
+    credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
     uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL (must be absolute)
-    opts: {
-      credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
-    }
   })
 }
 


### PR DESCRIPTION
They updated their API and [no longer](https://github.com/apollographql/apollo-link/tree/master/packages/apollo-link-http#options) accept `opts`.