### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: node_js
 sudo: true
 dist: trusty
 node_js:
+  - "node"
+  - "10"
+  - "8"
   - "6"
 cache:
   directories:
     - node_modules
+install: npm install


### PR DESCRIPTION
We should tests against all current LTS and stable releases of Node.js.