### PR TITLE
Adds missing comma to example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import { HttpLink } from 'apollo-link-http'
 // can also be a function that accepts a `context` object (SSR only) and returns a config
 const config = {
   link: new HttpLink({
-    credentials: 'same-origin' // Additional fetch() options like `credentials` or `headers`
+    credentials: 'same-origin', // Additional fetch() options like `credentials` or `headers`
     uri: 'https://api.graph.cool/simple/v1/cixmkt2ul01q00122mksg82pn', // Server URL
   })
 }


### PR DESCRIPTION
Adds a missing comma to the example in the README where the Apollo configuration is set up.