### PR TITLE
Adds babel/runtime to the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-dom": "16.8.6"
   },
   "dependencies": {
+    "@babel/runtime": "^7.4.5",
     "isomorphic-unfetch": "^3.0.0",
     "prop-types": "15.7.2",
     "prop-types-exact": "1.2.0",


### PR DESCRIPTION
Because of `@babel/plugin-transform-runtime`, the transpiled files have an hidden dependency in `@babel/runtime` (cf [here](https://cdn.jsdelivr.net/npm/next-apollo@3.1.9/dist/index.js), at the top of the file).