### PR TITLE
Support getStaticProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ export default withApollo({ ssr: true })(Page);
 
 That's it!
 
+## Advanced
+### SSG (getStaticProps):
+If you want to pre-generate your page, then do the following:
+
+```
+export default withApollo({ ssr: false })(YourPage)
+export const getStaticProps = getStaticApolloProps<Props, Params>(YourPage)
+```
+
+### ISR (getStaticProps + revalidate):
+If you want to pre-generate your page, but keep updating it every N seconds, then do the following:
+
+```
+export default withApollo({ ssr: false })(YourPage)
+
+// Update every 60 seconds
+export const getStaticProps = getStaticApolloProps<Props, Params>(YourPage, { revalidate: 60 })
+
 ## How Does It Work?
 
 Next-apollo integrates Apollo seamlessly with Next by wrapping our pages inside a higher-order component (HOC). Using a HOC pattern we're able to pass down a central store of query result data created by Apollo into our React component hierarchy defined inside each page of our Next application.

--- a/src/getStaticApolloProps.tsx
+++ b/src/getStaticApolloProps.tsx
@@ -1,0 +1,81 @@
+import { ParsedUrlQuery } from 'querystring'
+
+import { ApolloClient, ApolloProvider } from '@apollo/client'
+import { GetStaticProps } from 'next'
+import type { NextRouter } from 'next/dist/next-server/lib/router/router'
+import React from 'react'
+
+export type StaticApolloProps = {
+  apolloState: object
+  generatedAt: string
+  revalidate?: number | null
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const notImplemented = (..._args: any): any => {
+  throw new Error("Can't be called from a static page")
+}
+
+const baseFakeRouter = {
+  route: '',
+  pathname: '',
+  asPath: '',
+  basePath: '',
+  push: notImplemented,
+  replace: notImplemented,
+  reload: notImplemented,
+  back: notImplemented,
+  prefetch: notImplemented,
+  beforePopState: notImplemented,
+  events: {
+    on: notImplemented,
+    off: notImplemented,
+    emit: notImplemented
+  },
+  isFallback: false,
+  isReady: false
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getStaticApolloProps = (apolloClient: ApolloClient<any>) => <
+  TParams extends ParsedUrlQuery = ParsedUrlQuery
+>(
+  Page: React.ComponentType<{}>,
+  { revalidate }: { revalidate?: number } = {}
+): GetStaticProps<StaticApolloProps, TParams> => {
+  return async (context) => {
+    const { params, locales, locale, defaultLocale } = context
+    // https://github.com/vercel/next.js/blob/48acc479f3befb70de800392315831ed7defa4d8/packages/next/next-server/lib/router/router.ts#L250-L259
+    const router: NextRouter = {
+      query: params as ParsedUrlQuery,
+      locales,
+      locale,
+      defaultLocale,
+      ...baseFakeRouter
+    }
+
+    const { getDataFromTree } = await import('@apollo/client/react/ssr')
+    const { RouterContext } = await import(
+      'next/dist/next-server/lib/router-context'
+    )
+
+    const PrerenderComponent = () => (
+      <ApolloProvider client={apolloClient}>
+        <RouterContext.Provider value={router}>
+          <Page />
+        </RouterContext.Provider>
+      </ApolloProvider>
+    )
+
+    await getDataFromTree(<PrerenderComponent />)
+
+    return {
+      props: {
+        apolloState: apolloClient.cache.extract(),
+        generatedAt: new Date().toISOString(),
+        revalidate: revalidate || null
+      },
+      revalidate
+    }
+  }
+}

--- a/src/getStaticApolloProps.tsx
+++ b/src/getStaticApolloProps.tsx
@@ -33,7 +33,9 @@ const baseFakeRouter = {
     emit: notImplemented
   },
   isFallback: false,
-  isReady: false
+  isReady: false,
+  isLocaleDomain: false,
+  isPreview: false
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/getStaticApolloProps.tsx
+++ b/src/getStaticApolloProps.tsx
@@ -37,7 +37,7 @@ const baseFakeRouter = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const getStaticApolloProps = (apolloClient: ApolloClient<any>) => <
+const getStaticApolloProps = (apolloClient: ApolloClient<any>) => <
   TParams extends ParsedUrlQuery = ParsedUrlQuery
 >(
   Page: React.ComponentType<{}>,
@@ -79,3 +79,5 @@ export const getStaticApolloProps = (apolloClient: ApolloClient<any>) => <
     }
   }
 }
+
+export default getStaticApolloProps;

--- a/src/getStaticApolloProps.tsx
+++ b/src/getStaticApolloProps.tsx
@@ -75,7 +75,8 @@ const getStaticApolloProps = (apolloClient: ApolloClient<any>) => <
       props: {
         apolloState: apolloClient.cache.extract(),
         generatedAt: new Date().toISOString(),
-        revalidate: revalidate || null
+        revalidate: revalidate || null,
+        clearCacheOnPageEntry: true
       },
       revalidate
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import withApollo from "./withApollo";
+import getStaticApolloProps from './getStaticApolloProps';
 
-export { withApollo };
+export { withApollo, getStaticApolloProps };


### PR DESCRIPTION
This PR addresses #92.

I have tested this with a test repo with static rendering. I removed the callback feature in next-apollo-ts, since it can be implemented with composition. I also did not update withApollo in this repository to [revalidate](next-apollo-ts) as is done in next-apollo-ts. You can test these additions and see a clean history of my changes in [my fork of the repo](https://github.com/chrbala/next-apollo-ts).